### PR TITLE
Correct import from collections module for >=3.10

### DIFF
--- a/scabha/schema_utils.py
+++ b/scabha/schema_utils.py
@@ -1,10 +1,15 @@
+import sys
 from typing import *
 import click
 from .cargo import Parameter
 from .exceptions import SchemaError
 from dataclasses import make_dataclass, field
 from omegaconf import OmegaConf
-from collections import OrderedDict, MutableSet, MutableSequence, MutableMapping
+from collections import OrderedDict
+if sys.version_info >= (3, 10):
+    from collections.abc import MutableSet, MutableSequence, MutableMapping
+else:
+    from collections import MutableSet, MutableSequence, MutableMapping
 
 def schema_to_dataclass(io: Dict[str, Parameter], class_name: str, bases=(), post_init: Optional[Callable] =None):
     """Converts a scabha schema to a dataclass.


### PR DESCRIPTION
Versions <Python3.10 fetch modules: `MutableSet`, `MutableSequence` and `MutableMap` from `collections`. Version >=Python3.10 fetch these modules from `collections.abc`. 

This pull request makes this check and imports appropriately depending on the Python version in use.